### PR TITLE
feat(#12): support conditional OnDone on invoke actions

### DIFF
--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,5 +1,6 @@
 import '../automata.dart';
 
+/// Base Exception that all Automata's validations exceptions should implement.
 abstract class AutomataValidationException implements Exception {}
 
 /// [Exception] thrown when a [StateMachine] is defined without any

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,15 +1,17 @@
 import '../automata.dart';
 
+abstract class AutomataValidationException implements Exception {}
+
 /// [Exception] thrown when a [StateMachine] is defined without any
 /// atomic state node.
-class NoAtomicStateNodeException implements Exception {
+class NoAtomicStateNodeException implements AutomataValidationException {
   @override
   String toString() => 'No atomic nodes in this state machine';
 }
 
 /// [Exception] thrown when a node already has a transition for a given
 /// event without condition.
-class UnreachableTransitionException implements Exception {
+class UnreachableTransitionException implements AutomataValidationException {
   final Type event;
 
   const UnreachableTransitionException(this.event);
@@ -18,9 +20,19 @@ class UnreachableTransitionException implements Exception {
   String toString() => 'The transition with Event $event is not reachable.';
 }
 
+/// [Exception] thrown when a invoke definition is not valid.
+class InvalidInvokeDefinitionException implements AutomataValidationException {
+  final String message;
+
+  const InvalidInvokeDefinitionException(this.message);
+
+  @override
+  String toString() => message;
+}
+
 /// [Exception] thrown when a node already has a child node for the given
 /// [State].
-class DuplicateStateException implements Exception {
+class DuplicateStateException implements AutomataValidationException {
   final Type state;
 
   const DuplicateStateException(this.state);
@@ -32,7 +44,7 @@ class DuplicateStateException implements Exception {
 
 /// [Exception] thrown when onDone is placed in a state that doesnt have any
 /// terminal child.
-class InvalidOnDoneCallbackException implements Exception {
+class InvalidOnDoneCallbackException implements AutomataValidationException {
   final Type state;
   final StateNodeType stateNodeType;
 
@@ -62,7 +74,7 @@ class InvalidOnDoneCallbackException implements Exception {
 
 /// [Exception] thrown when a node already has a child node for the given
 /// [State].
-class UnreachableInitialStateException implements Exception {
+class UnreachableInitialStateException implements AutomataValidationException {
   final Type currentState;
   final Type initialState;
 

--- a/lib/src/invoke_definition.dart
+++ b/lib/src/invoke_definition.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 
 import 'state_machine_value.dart';
 import 'state_node.dart';
@@ -24,13 +25,15 @@ class InvokeDefinition<S extends AutomataState, E extends AutomataEvent,
   ///
   /// See also:
   /// - [InvokeDefinition.onDone]
-  final Map<Type, TransitionDefinition> _onDoneTransitionsMap = {};
+  @internal
+  final Map<Type, TransitionDefinition> onDoneTransitionsMap = {};
 
   /// Failure transition.
   ///
   /// See also:
   /// - [InvokeDefinition.onError]
-  late final TransitionDefinition _onErrorTransition;
+  @internal
+  TransitionDefinition? onErrorTransition;
 
   /// Invoke's async callback.
   ///
@@ -61,7 +64,7 @@ class InvokeDefinition<S extends AutomataState, E extends AutomataEvent,
     List<Action<DoneInvokeEvent<_Result>>>? actions,
     GuardCondition<DoneInvokeEvent<_Result>>? condition,
   }) {
-    _onDoneTransitionsMap[Target] =
+    onDoneTransitionsMap[Target] =
         TransitionDefinition<S, DoneInvokeEvent<_Result>, Target>(
       sourceStateNode: sourceStateNode,
       targetState: Target,
@@ -74,7 +77,7 @@ class InvokeDefinition<S extends AutomataState, E extends AutomataEvent,
   void onError<Target extends AutomataState>({
     List<Action<ErrorEvent>>? actions,
   }) {
-    _onErrorTransition = TransitionDefinition<S, ErrorEvent, Target>(
+    onErrorTransition = TransitionDefinition<S, ErrorEvent, Target>(
       sourceStateNode: sourceStateNode,
       targetState: Target,
       actions: actions,
@@ -89,7 +92,7 @@ class InvokeDefinition<S extends AutomataState, E extends AutomataEvent,
 
       final doneInvokeEvent = DoneInvokeEvent<Result>(id: _id, data: result);
 
-      final matchedTransition = _onDoneTransitionsMap.values.firstWhereOrNull(
+      final matchedTransition = onDoneTransitionsMap.values.firstWhereOrNull(
         (element) {
           // ignore: avoid_dynamic_calls
           final dynamic condition = (element as dynamic).condition;
@@ -109,7 +112,7 @@ class InvokeDefinition<S extends AutomataState, E extends AutomataEvent,
 
       matchedTransition.trigger(value, doneInvokeEvent);
     } on Object catch (e) {
-      _onErrorTransition.trigger(
+      onErrorTransition?.trigger(
         value,
         PlatformErrorEvent(exception: e),
       );

--- a/lib/src/state_node.dart
+++ b/lib/src/state_node.dart
@@ -48,7 +48,10 @@ class StateNodeDefinition<S extends AutomataState> implements StateNode {
   @internal
   final Map<Type, List<TransitionDefinition>> eventTransitionsMap = {};
 
-  InvokeDefinition? _invoke;
+  /// Optional invoke definition.
+  /// Used to call external async services.
+  @internal
+  InvokeDefinition? invokeDefinition;
 
   /// Action invoked on entry this [StateNodeDefinition].
   OnEntryAction? _onEntryAction;
@@ -220,8 +223,8 @@ class StateNodeDefinition<S extends AutomataState> implements StateNode {
     E event,
   ) {
     _onEntryAction?.call(event);
-    if (_invoke != null) {
-      _invoke?.execute(value, event);
+    if (invokeDefinition != null) {
+      invokeDefinition?.execute(value, event);
     }
   }
 
@@ -290,9 +293,11 @@ class StateNodeDefinition<S extends AutomataState> implements StateNode {
   /// Attach a [InvokeDefinition] to this node.
   @override
   void invoke<Result>({InvokeBuilder? builder}) {
-    _invoke = InvokeDefinition<S, AutomataEvent, Result>(sourceStateNode: this);
+    invokeDefinition = InvokeDefinition<S, AutomataEvent, Result>(
+      sourceStateNode: this,
+    );
 
-    builder?.call(_invoke!);
+    builder?.call(invokeDefinition!);
   }
 
   @override

--- a/lib/src/validators/extensions.dart
+++ b/lib/src/validators/extensions.dart
@@ -9,6 +9,8 @@ import 'validators.dart';
 extension StateMachineValidator on StateMachine {
   /// Kick start validation by invoking validate on the rootNode, which will
   /// then traverse the statechart invoking validate on all nodes.
+  ///
+  /// If any error is found, an [AutomataValidationException] will be thrown.
   void validate() {
     final _validators = [
       ValidateAtomicStates(this),
@@ -32,6 +34,7 @@ extension StateNodeDefinitionValidator on StateNodeDefinition {
     final _validators = [
       ValidateUnreachableTransitions(this),
       ValidateInvalidOnDoneCallback(this),
+      ValidateInvokeDefinition(this),
     ];
 
     for (final validator in _validators) {

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -43,6 +43,41 @@ class ValidateAtomicStates extends Validator<StateMachine> {
   }
 }
 
+/// Throws [InvalidInvokeDefinitionException] when:
+///   1. Invoke is defined in a terminal node
+///   2. There is no OnDone definition
+///   3. There is no OnError definition
+class ValidateInvokeDefinition extends Validator<StateNodeDefinition> {
+  const ValidateInvokeDefinition(StateNodeDefinition data) : super(data);
+
+  @override
+  void call() {
+    final invokeDefinition = data.invokeDefinition;
+
+    if (invokeDefinition == null) {
+      return;
+    }
+
+    if (data.stateNodeType == StateNodeType.terminal) {
+      throw const InvalidInvokeDefinitionException(
+        "Can't define a invoke in a terminal node",
+      );
+    }
+
+    if (invokeDefinition.onDoneTransitionsMap.isEmpty) {
+      throw const InvalidInvokeDefinitionException(
+        'Missing a one OnDone transition',
+      );
+    }
+
+    if (invokeDefinition.onErrorTransition == null) {
+      throw const InvalidInvokeDefinitionException(
+        'Missing OnError transition',
+      );
+    }
+  }
+}
+
 /// Throws [UnreachableTransitionException] when a node defines
 /// two transitions without conditions to the same [Event]. Only the first
 /// one will ever be matched and therefore it's the only valid.

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -60,13 +60,13 @@ class ValidateInvokeDefinition extends Validator<StateNodeDefinition> {
 
     if (data.stateNodeType == StateNodeType.terminal) {
       throw const InvalidInvokeDefinitionException(
-        "Can't define a invoke in a terminal node",
+        "Can't define an invoke in a terminal node",
       );
     }
 
     if (invokeDefinition.onDoneTransitionsMap.isEmpty) {
       throw const InvalidInvokeDefinitionException(
-        'Missing a one OnDone transition',
+        'Missing at least one OnDone transition',
       );
     }
 

--- a/test/invoke_test.dart
+++ b/test/invoke_test.dart
@@ -29,94 +29,236 @@ void main() {
     );
   });
 
-  test('should be able to resolve successfully', () async {
-    const result = _TestMockResult(value: 'Something');
-    final invokeSrcCallback = _MockSrcCallbackFunction();
-    when(() => invokeSrcCallback(any())).thenAnswer((_) async => result);
+  group('with single onDone/onError transitions', () {
+    StateMachine _createMachine<S extends AutomataState>({
+      required InvokeSrcCallback<_TestMockResult> invokeSrcCallback,
+      required _MockOnDoneCallbackFunction onDoneCallback,
+      required _MockOnErrorCallbackFunction onErrorCallback,
+    }) {
+      return StateMachine.create(
+        (g) => g
+          ..initial<_Idle>()
+          ..state<_Idle>(
+            builder: (b) => b..on<_OnFetch, _Loading>(),
+          )
+          ..state<_Loading>(
+            builder: (b) => b
+              ..invoke<_TestMockResult>(
+                builder: (b) => b
+                  ..id('fetchUser')
+                  ..src(invokeSrcCallback)
+                  ..onDone<_Success, _TestMockResult>(actions: [onDoneCallback])
+                  ..onError<_Failure>(actions: [onErrorCallback]),
+              ),
+          )
+          ..state<_Success>(type: StateNodeType.terminal)
+          ..state<_Failure>(
+            builder: (b) => b..on<_OnRetry, _Loading>(),
+          ),
+      );
+    }
 
-    final onDoneCallback = _MockOnDoneCallbackFunction();
-    final onErrorCallback = _MockOnErrorCallbackFunction();
-    final machine = _createMachine(
-      invokeSrcCallback: invokeSrcCallback,
-      onDoneCallback: onDoneCallback,
-      onErrorCallback: onErrorCallback,
-    );
-    machine.send(_OnFetch());
-    expect(machine.isInState(_Loading), isTrue);
+    test('should be able to resolve successfully', () async {
+      const result = _TestMockResult(value: 'Something');
+      final invokeSrcCallback = _MockSrcCallbackFunction();
+      when(() => invokeSrcCallback(any())).thenAnswer((_) async => result);
 
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    expect(machine.isInState(_Success), isTrue);
+      final onDoneCallback = _MockOnDoneCallbackFunction();
+      final onErrorCallback = _MockOnErrorCallbackFunction();
+      final machine = _createMachine(
+        invokeSrcCallback: invokeSrcCallback,
+        onDoneCallback: onDoneCallback,
+        onErrorCallback: onErrorCallback,
+      );
+      machine.send(_OnFetch());
+      expect(machine.isInState(_Loading), isTrue);
 
-    verify(
-      () =>
-          onDoneCallback(const DoneInvokeEvent(id: 'fetchUser', data: result)),
-    ).called(1);
-  });
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(machine.isInState(_Success), isTrue);
 
-  test('should be able to move to error state', () async {
-    final exception = Exception('Something went wrong');
-    final invokeSrcCallback = _MockSrcCallbackFunction();
-
-    when(() => invokeSrcCallback(any())).thenAnswer((_) async {
-      throw exception;
+      verify(
+        () => onDoneCallback(
+          const DoneInvokeEvent(id: 'fetchUser', data: result),
+        ),
+      ).called(1);
     });
 
-    final onDoneCallback = _MockOnDoneCallbackFunction();
-    final onErrorCallback = _MockOnErrorCallbackFunction();
-    final machine = _createMachine(
-      invokeSrcCallback: invokeSrcCallback,
-      onDoneCallback: onDoneCallback,
-      onErrorCallback: onErrorCallback,
-    );
-    machine.send(_OnFetch());
-    expect(machine.isInState(_Loading), isTrue);
+    test('should be able to move to error state', () async {
+      final exception = Exception('Something went wrong');
+      final invokeSrcCallback = _MockSrcCallbackFunction();
 
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    expect(machine.isInState(_Failure), isTrue);
+      when(() => invokeSrcCallback(any())).thenAnswer((_) async {
+        throw exception;
+      });
 
-    verify(
-      () => onErrorCallback(PlatformErrorEvent(exception: exception)),
-    ).called(1);
-  });
+      final onDoneCallback = _MockOnDoneCallbackFunction();
+      final onErrorCallback = _MockOnErrorCallbackFunction();
+      final machine = _createMachine(
+        invokeSrcCallback: invokeSrcCallback,
+        onDoneCallback: onDoneCallback,
+        onErrorCallback: onErrorCallback,
+      );
+      machine.send(_OnFetch());
+      expect(machine.isInState(_Loading), isTrue);
 
-  test('should be able to retry', () async {
-    final exception = Exception('Something went wrong');
-    final invokeSrcCallback = _MockSrcCallbackFunction();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(machine.isInState(_Failure), isTrue);
 
-    when(() => invokeSrcCallback(any())).thenAnswer((_) async {
-      throw exception;
+      verify(
+        () => onErrorCallback(PlatformErrorEvent(exception: exception)),
+      ).called(1);
     });
 
-    final onDoneCallback = _MockOnDoneCallbackFunction();
-    final onErrorCallback = _MockOnErrorCallbackFunction();
-    final machine = _createMachine(
-      invokeSrcCallback: invokeSrcCallback,
-      onDoneCallback: onDoneCallback,
-      onErrorCallback: onErrorCallback,
-    );
-    machine.send(_OnFetch());
-    expect(machine.isInState(_Loading), isTrue);
+    test('should be able to retry', () async {
+      final exception = Exception('Something went wrong');
+      final invokeSrcCallback = _MockSrcCallbackFunction();
 
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    expect(machine.isInState(_Failure), isTrue);
-    verify(
-      () => onErrorCallback(PlatformErrorEvent(exception: exception)),
-    ).called(1);
+      when(() => invokeSrcCallback(any())).thenAnswer((_) async {
+        throw exception;
+      });
 
-    const result = _TestMockResult(value: 'Something');
-    when(() => invokeSrcCallback(any())).thenAnswer((_) async => result);
+      final onDoneCallback = _MockOnDoneCallbackFunction();
+      final onErrorCallback = _MockOnErrorCallbackFunction();
+      final machine = _createMachine(
+        invokeSrcCallback: invokeSrcCallback,
+        onDoneCallback: onDoneCallback,
+        onErrorCallback: onErrorCallback,
+      );
+      machine.send(_OnFetch());
+      expect(machine.isInState(_Loading), isTrue);
 
-    machine.send(_OnRetry());
-    expect(machine.isInState(_Loading), isTrue);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(machine.isInState(_Failure), isTrue);
+      verify(
+        () => onErrorCallback(PlatformErrorEvent(exception: exception)),
+      ).called(1);
 
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    expect(machine.isInState(_Success), isTrue);
+      const result = _TestMockResult(value: 'Something');
+      when(() => invokeSrcCallback(any())).thenAnswer((_) async => result);
 
-    verify(
-      () => onDoneCallback(
-        const DoneInvokeEvent(id: 'fetchUser', data: result),
-      ),
-    ).called(1);
+      machine.send(_OnRetry());
+      expect(machine.isInState(_Loading), isTrue);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(machine.isInState(_Success), isTrue);
+
+      verify(
+        () => onDoneCallback(
+          const DoneInvokeEvent(id: 'fetchUser', data: result),
+        ),
+      ).called(1);
+    });
+  });
+
+  group('with multiple conditional transitions', () {
+    StateMachine _createMachine<S extends AutomataState>({
+      required InvokeSrcCallback<_TestMockResult> invokeSrcCallback,
+      _MockOnDoneCallbackFunction? onDoneCallbackA,
+      _MockOnDoneCallbackFunction? onDoneCallbackB,
+      _MockOnErrorCallbackFunction? onErrorCallback,
+    }) {
+      return StateMachine.create(
+        (g) => g
+          ..initial<_Idle>()
+          ..state<_Idle>(
+            builder: (b) => b..on<_OnFetch, _Loading>(),
+          )
+          ..state<_Loading>(
+            builder: (b) => b
+              ..invoke<_TestMockResult>(
+                builder: (b) => b
+                  ..id('fetchUser')
+                  ..src(invokeSrcCallback)
+                  ..onDone<_Success, _TestMockResult>(
+                    condition: ((event) => event.data.value == 'UseA'),
+                    actions: [
+                      onDoneCallbackA ?? _MockOnDoneCallbackFunction(),
+                    ],
+                  )
+                  ..onDone<_SuccessB, _TestMockResult>(
+                    condition: ((event) => event.data.value == 'UseB'),
+                    actions: [
+                      onDoneCallbackB ?? _MockOnDoneCallbackFunction(),
+                    ],
+                  )
+                  ..onError<_Failure>(
+                    actions: [
+                      onErrorCallback ?? _MockOnErrorCallbackFunction(),
+                    ],
+                  ),
+              ),
+          )
+          ..state<_Success>(type: StateNodeType.terminal)
+          ..state<_SuccessB>(type: StateNodeType.terminal)
+          ..state<_Failure>(
+            builder: (b) => b..on<_OnRetry, _Loading>(),
+          ),
+      );
+    }
+
+    setUpAll(() {
+      registerFallbackValue(_MockEvent());
+      registerFallbackValue(
+        const DoneInvokeEvent<_TestMockResult>(
+          id: 'fetchUser',
+          data: _TestMockResult(value: 'placeholder'),
+        ),
+      );
+    });
+
+    test('should transition to the first onDone', () async {
+      const result = _TestMockResult(value: 'UseA');
+      final invokeSrcCallback = _MockSrcCallbackFunction();
+      when(() => invokeSrcCallback(any())).thenAnswer((_) async => result);
+
+      final onDoneCallbackA = _MockOnDoneCallbackFunction();
+      final onDoneCallbackB = _MockOnDoneCallbackFunction();
+
+      final machine = _createMachine(
+        invokeSrcCallback: invokeSrcCallback,
+        onDoneCallbackA: onDoneCallbackA,
+        onDoneCallbackB: onDoneCallbackB,
+      );
+
+      machine.send(_OnFetch());
+      expect(machine.isInState(_Loading), isTrue);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(machine.isInState(_Success), isTrue);
+
+      verify(
+        () => onDoneCallbackA(
+          const DoneInvokeEvent(id: 'fetchUser', data: result),
+        ),
+      ).called(1);
+    });
+
+    test('should transition to the second onDone', () async {
+      const result = _TestMockResult(value: 'UseB');
+      final invokeSrcCallback = _MockSrcCallbackFunction();
+      when(() => invokeSrcCallback(any())).thenAnswer((_) async => result);
+
+      final onDoneCallbackA = _MockOnDoneCallbackFunction();
+      final onDoneCallbackB = _MockOnDoneCallbackFunction();
+
+      final machine = _createMachine(
+        invokeSrcCallback: invokeSrcCallback,
+        onDoneCallbackA: onDoneCallbackA,
+        onDoneCallbackB: onDoneCallbackB,
+      );
+
+      machine.send(_OnFetch());
+      expect(machine.isInState(_Loading), isTrue);
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(machine.isInState(_SuccessB), isTrue);
+
+      verify(
+        () => onDoneCallbackB(
+          const DoneInvokeEvent(id: 'fetchUser', data: result),
+        ),
+      ).called(1);
+    });
   });
 }
 
@@ -128,6 +270,8 @@ class _Failure extends AutomataState {}
 
 class _Success extends AutomataState {}
 
+class _SuccessB extends AutomataState {}
+
 class _OnFetch extends AutomataEvent {}
 
 class _OnRetry extends AutomataEvent {}
@@ -136,32 +280,4 @@ class _TestMockResult {
   final String value;
 
   const _TestMockResult({required this.value});
-}
-
-StateMachine _createMachine<S extends AutomataState>({
-  required InvokeSrcCallback<_TestMockResult> invokeSrcCallback,
-  required _MockOnDoneCallbackFunction onDoneCallback,
-  required _MockOnErrorCallbackFunction onErrorCallback,
-}) {
-  return StateMachine.create(
-    (g) => g
-      ..initial<_Idle>()
-      ..state<_Idle>(
-        builder: (b) => b..on<_OnFetch, _Loading>(),
-      )
-      ..state<_Loading>(
-        builder: (b) => b
-          ..invoke<_TestMockResult>(
-            builder: (b) => b
-              ..id('fetchUser')
-              ..src(invokeSrcCallback)
-              ..onDone<_Success, _TestMockResult>(actions: [onDoneCallback])
-              ..onError<_Failure>(actions: [onErrorCallback]),
-          ),
-      )
-      ..state<_Success>(type: StateNodeType.terminal)
-      ..state<_Failure>(
-        builder: (b) => b..on<_OnRetry, _Loading>(),
-      ),
-  );
 }


### PR DESCRIPTION
### Related to
#12 

### Context
Currently, the Invoke definition only allows a single OnDone and OnError. This isn't flexible enough, in this PR we want to allow multiple OnDone. Each OnDone can have a `condition` when an invoke finishes successfully, automata will go through the OnDone definitions and pick the first one that the condition is not defined or it evaluates to true.

### Approach

Usage example:

```dart
StateMachine.create(
        (g) => g
          ..initial<_Idle>()
          ..state<_Idle>(
            builder: (b) => b..on<_OnFetch, _Loading>(),
          )
          ..state<_Loading>(
            builder: (b) => b
              ..invoke<_TestMockResult>(
                builder: (b) => b
                  ..id('fetchUser')
                  ..src(invokeSrcCallback)

                  // first onDone which will be entered if response value is true
                  ..onDone<_Success, _TestMockResult>(
                    condition: ((event) => event.data.value == true),
                    actions: [() {...}],
                  )

                  // first onDone which will be entered if response value is false
                  ..onDone<_SuccessB, _TestMockResult>(
                    condition: ((event) => event.data.value == false),
                    actions: [() {...}],
                  )
                  ..onError<_Failure>(
                    actions: [() {...}],
                  ),
              ),
          )
          ..state<_Success>(type: StateNodeType.terminal)
          ..state<_SuccessB>(type: StateNodeType.terminal)
          ..state<_Failure>(
            builder: (b) => b..on<_OnRetry, _Loading>(),
          ),
      );
```
